### PR TITLE
[PR-5761] Handle monitor ids with dots

### DIFF
--- a/examples/all_monitor_types.yaml
+++ b/examples/all_monitor_types.yaml
@@ -11,20 +11,20 @@ monitors:
   - id: freshness_financial_statement
     type: freshness
     monitored_ids:
-      - bq-synq-demo::nyc_taxi::financial_statement
+      - bq-synq-demo.nyc_taxi.financial_statement
     time_partitioning: month
     expression: "month"
 
   # 2) Volume per month
   - id: volume_financial_statement
     type: volume
-    monitored_id: bq-synq-demo::nyc_taxi::financial_statement
+    monitored_id: bq-synq-demo.nyc_taxi.financial_statement
     time_partitioning: month
 
   # 3) Field stats on key metrics with BALANCED sensitivity
   - id: stats_financial_statement
     type: field_stats
-    monitored_id: bq-synq-demo::nyc_taxi::financial_statement
+    monitored_id: bq-synq-demo.nyc_taxi.financial_statement
     time_partitioning: month
     fields:
       - total_revenue
@@ -37,7 +37,7 @@ monitors:
   - id: custom_financial_statement_revenue_nonnegative
     type: custom_numeric
     monitored_ids:
-      - bq-synq-demo::nyc_taxi::financial_statement
+      - bq-synq-demo.nyc_taxi.financial_statement
     time_partitioning: month
     metric_aggregation: "MIN(total_revenue)"
     mode:

--- a/examples/complex.yaml
+++ b/examples/complex.yaml
@@ -15,14 +15,14 @@ monitors:
     expression: "created_at"
     severity: WARNING
     monitored_ids:
-      - ch-prod::anomalies::corrections_v2
-      - ch-prod::anomalies::external_sqltests
+      - ch-prod.anomalies.corrections_v2
+      - ch-prod.anomalies.external_sqltests
 
   - id: volume_on_logs
     type: volume
     severity: WARNING
     monitored_ids:
-      - bq-synq-dwh::petr::kernel_assets__stg_assets
+      - bq-synq-dwh.petr.kernel_assets__stg_assets
     segmentation:
       expression: "country"
     filter: "country IN ('US', 'CA')"
@@ -33,7 +33,7 @@ monitors:
       - status
       - order_date
     monitored_ids:
-      - bq-synq-dwh::test::orders
+      - bq-synq-dwh.test.orders
     mode:
       anomaly_engine:
         sensitivity: BALANCED
@@ -45,7 +45,7 @@ monitors:
     metric_aggregation: "COUNT(DISTINCT user_id)"
     time_partitioning: "order_date"
     monitored_ids:
-      - bq-synq-dwh::test::orders
+      - bq-synq-dwh.test.orders
     mode:
       fixed_thresholds:
         min: 100

--- a/examples/custom_name.yaml
+++ b/examples/custom_name.yaml
@@ -6,4 +6,4 @@ monitors:
     type: volume
     time_partitioning: created_at
     monitored_ids:
-      - ch-prod::default::runs
+      - ch-prod.default.runs

--- a/examples/custom_numeric.yaml
+++ b/examples/custom_numeric.yaml
@@ -6,9 +6,8 @@ monitors:
     metric_aggregation: "COUNT(DISTINCT workspace)"
     time_partitioning: created_at
     monitored_ids:
-      - ch-prod::default::runs
+      - ch-prod.default.runs
     mode:
       fixed_thresholds:
         max: 1000
-    filter:
-      created_at > today()
+    filter: created_at > today()

--- a/examples/minimal.yaml
+++ b/examples/minimal.yaml
@@ -5,4 +5,4 @@ monitors:
     type: volume
     time_partitioning: created_at
     monitored_ids:
-      - ch-prod::default::runs
+      - ch-prod.default.runs

--- a/examples/namespacing.yaml
+++ b/examples/namespacing.yaml
@@ -1,5 +1,5 @@
-# Monitors change for a given namespace is atomic operation - we collect 
-# all defined monitors in code, diff them with current state in Synq and 
+# Monitors change for a given namespace is atomic operation - we collect
+# all defined monitors in code, diff them with current state in Synq and
 # apply the changes. Creating namespaces allows different teams to manage
 # their monitors independently.
 
@@ -10,4 +10,4 @@ monitors:
     type: volume
     time_partitioning: created_at
     monitored_ids:
-      - ch-prod::default::runs
+      - ch-prod.default.runs

--- a/examples/schedule_daily.yaml
+++ b/examples/schedule_daily.yaml
@@ -7,4 +7,4 @@ monitors:
     schedule:
       daily: 15 # runs at 15th minute since midnight
     monitored_ids:
-      - ch-prod::default::runs
+      - ch-prod.default.runs

--- a/examples/schedule_hourly.yaml
+++ b/examples/schedule_hourly.yaml
@@ -7,4 +7,4 @@ monitors:
     schedule:
       hourly: 15 # runs at 15th minute of every hour
     monitored_ids:
-      - ch-prod::default::runs
+      - ch-prod.default.runs

--- a/examples/severity_warn.yaml
+++ b/examples/severity_warn.yaml
@@ -6,4 +6,4 @@ monitors:
     time_partitioning: created_at
     severity: WARNING # change severity to WARNING
     monitored_ids:
-      - ch-prod::default::runs
+      - ch-prod.default.runs

--- a/yaml/exports/all_monitor_types.yaml.snap
+++ b/yaml/exports/all_monitor_types.yaml.snap
@@ -1,0 +1,55 @@
+
+[TestYAMLGeneratorSuite/TestExamples - 1]
+namespace: financial_data
+monitors:
+    - id: 116844a4-aed0-56b4-bd75-350f26532aae
+      name: freshness_financial_statement
+      type: freshness
+      expression: month
+      monitored_id: bq-synq-demo.nyc_taxi.financial_statement
+      severity: ERROR
+      time_partitioning: month
+      mode:
+        anomaly_engine:
+            sensitivity: BALANCED
+      schedule:
+        daily: 0
+    - id: e522340e-088a-5eb8-8ee6-77bebd3fbc57
+      name: volume_financial_statement
+      type: volume
+      monitored_id: bq-synq-demo.nyc_taxi.financial_statement
+      severity: ERROR
+      time_partitioning: month
+      mode:
+        anomaly_engine:
+            sensitivity: BALANCED
+      schedule:
+        daily: 0
+    - id: 5c6c57a2-91f5-5e87-be4c-497aac1a907f
+      name: stats_financial_statement
+      type: field_stats
+      monitored_id: bq-synq-demo.nyc_taxi.financial_statement
+      fields:
+        - total_revenue
+        - total_tips
+      severity: ERROR
+      time_partitioning: month
+      mode:
+        anomaly_engine:
+            sensitivity: BALANCED
+      schedule:
+        daily: 0
+    - id: e91ae608-1467-5afd-91db-d0ba786197b5
+      name: custom_financial_statement_revenue_nonnegative
+      type: custom_numeric
+      metric_aggregation: MIN(total_revenue)
+      monitored_id: bq-synq-demo.nyc_taxi.financial_statement
+      severity: ERROR
+      time_partitioning: month
+      mode:
+        fixed_thresholds:
+            min: 0
+      schedule:
+        daily: 0
+
+---

--- a/yaml/exports/complex.yaml.snap
+++ b/yaml/exports/complex.yaml.snap
@@ -1,0 +1,71 @@
+
+[TestYAMLGeneratorSuite/TestExamples - 1]
+namespace: data-team-pipeline
+monitors:
+    - id: e90ecd7b-111d-5f14-9da7-e94c08f67655
+      name: freshness_on_orders
+      type: freshness
+      expression: created_at
+      monitored_id: ch-prod.anomalies.corrections_v2
+      severity: WARNING
+      time_partitioning: created_at
+      mode:
+        anomaly_engine:
+            sensitivity: BALANCED
+      schedule:
+        daily: 0
+    - id: 24a0e18e-5ef3-5269-ba2b-fbec88270430
+      name: freshness_on_orders
+      type: freshness
+      expression: created_at
+      monitored_id: ch-prod.anomalies.external_sqltests
+      severity: WARNING
+      time_partitioning: created_at
+      mode:
+        anomaly_engine:
+            sensitivity: BALANCED
+      schedule:
+        daily: 0
+    - id: c20b07ae-27f5-50ff-ab17-7b11bed097dd
+      name: volume_on_logs
+      type: volume
+      monitored_id: bq-synq-dwh.petr.kernel_assets__stg_assets
+      segmentation:
+        expression: country
+      filter: country IN ('US', 'CA')
+      severity: WARNING
+      time_partitioning: created_at
+      mode:
+        anomaly_engine:
+            sensitivity: BALANCED
+      schedule:
+        daily: 0
+    - id: 911f832a-8ce5-5b14-930d-28d37a4f37b3
+      name: stats_on_user_fields
+      type: field_stats
+      monitored_id: bq-synq-dwh.test.orders
+      fields:
+        - status
+        - order_date
+      severity: ERROR
+      time_partitioning: created_at
+      mode:
+        anomaly_engine:
+            sensitivity: BALANCED
+      schedule:
+        daily: 0
+    - id: 9769be77-e584-5bd5-8289-8321b4a01f4f
+      name: custom_numeric_active_users
+      type: custom_numeric
+      metric_aggregation: COUNT(DISTINCT user_id)
+      monitored_id: bq-synq-dwh.test.orders
+      severity: ERROR
+      time_partitioning: order_date
+      mode:
+        fixed_thresholds:
+            min: 100
+            max: 10000
+      schedule:
+        daily: 0
+
+---

--- a/yaml/exports/custom_name.yaml.snap
+++ b/yaml/exports/custom_name.yaml.snap
@@ -1,0 +1,17 @@
+
+[TestYAMLGeneratorSuite/TestExamples - 1]
+namespace: ""
+monitors:
+    - id: cd7a6968-78a3-5c9a-8f0e-e2a6bbaae074
+      name: Runs volume daily
+      type: volume
+      monitored_id: ch-prod.default.runs
+      severity: ERROR
+      time_partitioning: created_at
+      mode:
+        anomaly_engine:
+            sensitivity: BALANCED
+      schedule:
+        daily: 0
+
+---

--- a/yaml/exports/custom_numeric.yaml.snap
+++ b/yaml/exports/custom_numeric.yaml.snap
@@ -1,0 +1,19 @@
+
+[TestYAMLGeneratorSuite/TestExamples - 1]
+namespace: ""
+monitors:
+    - id: 370fe457-ccc4-515d-a0e1-fc52f0234fbf
+      name: runs_unique_workspaces
+      type: custom_numeric
+      metric_aggregation: COUNT(DISTINCT workspace)
+      monitored_id: ch-prod.default.runs
+      filter: created_at > today()
+      severity: ERROR
+      time_partitioning: created_at
+      mode:
+        fixed_thresholds:
+            max: 1000
+      schedule:
+        daily: 0
+
+---

--- a/yaml/exports/minimal.yaml.snap
+++ b/yaml/exports/minimal.yaml.snap
@@ -1,0 +1,17 @@
+
+[TestYAMLGeneratorSuite/TestExamples - 1]
+namespace: ""
+monitors:
+    - id: cd7a6968-78a3-5c9a-8f0e-e2a6bbaae074
+      name: runs_volume_daily
+      type: volume
+      monitored_id: ch-prod.default.runs
+      severity: ERROR
+      time_partitioning: created_at
+      mode:
+        anomaly_engine:
+            sensitivity: BALANCED
+      schedule:
+        daily: 0
+
+---

--- a/yaml/exports/namespacing.yaml.snap
+++ b/yaml/exports/namespacing.yaml.snap
@@ -1,0 +1,17 @@
+
+[TestYAMLGeneratorSuite/TestExamples - 1]
+namespace: team-Y
+monitors:
+    - id: 303011a1-a77a-5b05-9f19-fc73b0bc14a9
+      name: runs_volume_daily
+      type: volume
+      monitored_id: ch-prod.default.runs
+      severity: ERROR
+      time_partitioning: created_at
+      mode:
+        anomaly_engine:
+            sensitivity: BALANCED
+      schedule:
+        daily: 0
+
+---

--- a/yaml/exports/schedule_daily.yaml.snap
+++ b/yaml/exports/schedule_daily.yaml.snap
@@ -1,0 +1,17 @@
+
+[TestYAMLGeneratorSuite/TestExamples - 1]
+namespace: ""
+monitors:
+    - id: cd7a6968-78a3-5c9a-8f0e-e2a6bbaae074
+      name: runs_volume_daily
+      type: volume
+      monitored_id: ch-prod.default.runs
+      severity: ERROR
+      time_partitioning: created_at
+      mode:
+        anomaly_engine:
+            sensitivity: BALANCED
+      schedule:
+        daily: 15
+
+---

--- a/yaml/exports/schedule_hourly.yaml.snap
+++ b/yaml/exports/schedule_hourly.yaml.snap
@@ -1,0 +1,17 @@
+
+[TestYAMLGeneratorSuite/TestExamples - 1]
+namespace: ""
+monitors:
+    - id: 5a6f522b-5fcc-57aa-b4ad-4b36db54c04f
+      name: runs_volume_hourly
+      type: volume
+      monitored_id: ch-prod.default.runs
+      severity: ERROR
+      time_partitioning: created_at
+      mode:
+        anomaly_engine:
+            sensitivity: BALANCED
+      schedule:
+        hourly: 15
+
+---

--- a/yaml/exports/segmentation.yaml.snap
+++ b/yaml/exports/segmentation.yaml.snap
@@ -1,0 +1,22 @@
+
+[TestYAMLGeneratorSuite/TestExamples - 1]
+namespace: ""
+monitors:
+    - id: 3251e5ce-e5da-5574-b39b-54f876e3a111
+      name: runs_volume_daily_by_status
+      type: volume
+      monitored_id: ch-prod.default.runs
+      segmentation:
+        expression: run_status
+        include_values:
+            - ERROR
+            - CRITICAL
+      severity: ERROR
+      time_partitioning: created_at
+      mode:
+        anomaly_engine:
+            sensitivity: BALANCED
+      schedule:
+        daily: 0
+
+---

--- a/yaml/exports/severity_warn.yaml.snap
+++ b/yaml/exports/severity_warn.yaml.snap
@@ -1,0 +1,17 @@
+
+[TestYAMLGeneratorSuite/TestExamples - 1]
+namespace: ""
+monitors:
+    - id: b6c784cf-7a31-5869-a56f-2000ba641961
+      name: runs_volume_warn
+      type: volume
+      monitored_id: ch-prod.default.runs
+      severity: WARNING
+      time_partitioning: created_at
+      mode:
+        anomaly_engine:
+            sensitivity: BALANCED
+      schedule:
+        daily: 0
+
+---

--- a/yaml/generator.go
+++ b/yaml/generator.go
@@ -50,7 +50,7 @@ func (p *YAMLGenerator) generateSingleMonitor(
 		Name:             protoMonitor.Name,
 		ConfigID:         p.configId,
 		Id:               protoMonitor.Id,
-		MonitoredID:      protoMonitor.MonitoredId.GetSynqPath().Path,
+		MonitoredID:      monitorIdWithDots(protoMonitor.MonitoredId.GetSynqPath().GetPath()),
 		TimePartitioning: protoMonitor.GetTimePartitioning().GetExpression(),
 	}
 

--- a/yaml/generator_test.go
+++ b/yaml/generator_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/getsynq/monitors_mgmt/uuid"
+	"github.com/gkampitakis/go-snaps/snaps"
 	"github.com/stretchr/testify/suite"
 	goyaml "gopkg.in/yaml.v3"
 )
@@ -58,8 +59,15 @@ func (s *YAMLGeneratorSuite) TestExamples() {
 		s.Require().False(conversionErrors.HasErrors(), conversionErrors.Error())
 
 		generator := NewYAMLGenerator(config.ConfigID, protoMonitors)
-		_, convErrors := generator.GenerateYAML()
+		config, convErrors := generator.GenerateYAML()
 		s.Require().False(convErrors.HasErrors())
+
+		bytes, err := goyaml.Marshal(config)
+		s.Require().NoError(err)
+		snaps.WithConfig(snaps.Dir("exports"), snaps.Filename(filepath.Base(file))).MatchSnapshot(
+			s.T(),
+			string(bytes),
+		)
 	}
 
 }

--- a/yaml/parser.go
+++ b/yaml/parser.go
@@ -72,7 +72,7 @@ func (p *YAMLParser) ConvertToMonitorDefinitions() ([]*pb.MonitorDefinition, Con
 		}
 
 		monitoredIds = lo.Map(monitoredIds, func(monitoredID string, _ int) string {
-			return handleMonitorID(monitoredID)
+			return monitorIdWithColons(monitoredID)
 		})
 
 		for _, monitoredID := range monitoredIds {
@@ -89,9 +89,12 @@ func (p *YAMLParser) ConvertToMonitorDefinitions() ([]*pb.MonitorDefinition, Con
 	return protoMonitors, errors
 }
 
-func handleMonitorID(monitorId string) string {
-	// replace all dots to colons
+func monitorIdWithColons(monitorId string) string {
 	return strings.ReplaceAll(monitorId, ".", "::")
+}
+
+func monitorIdWithDots(monitorId string) string {
+	return strings.ReplaceAll(monitorId, "::", ".")
 }
 
 // convertSingleMonitor converts a single YAML monitor to proto for a specific monitored ID

--- a/yaml/parser.go
+++ b/yaml/parser.go
@@ -7,6 +7,7 @@ import (
 	entitiesv1 "buf.build/gen/go/getsynq/api/protocolbuffers/go/synq/entities/v1"
 	pb "buf.build/gen/go/getsynq/api/protocolbuffers/go/synq/monitors/custom_monitors/v1"
 	"github.com/getsynq/monitors_mgmt/uuid"
+	"github.com/samber/lo"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
@@ -70,6 +71,10 @@ func (p *YAMLParser) ConvertToMonitorDefinitions() ([]*pb.MonitorDefinition, Con
 			monitoredIds = append(monitoredIds, yamlMonitor.MonitoredID)
 		}
 
+		monitoredIds = lo.Map(monitoredIds, func(monitoredID string, _ int) string {
+			return handleMonitorID(monitoredID)
+		})
+
 		for _, monitoredID := range monitoredIds {
 			protoMonitor, convErrors := convertSingleMonitor(&yamlMonitor, p.yamlConfig, monitoredID)
 			if convErrors.HasErrors() {
@@ -82,6 +87,11 @@ func (p *YAMLParser) ConvertToMonitorDefinitions() ([]*pb.MonitorDefinition, Con
 	}
 
 	return protoMonitors, errors
+}
+
+func handleMonitorID(monitorId string) string {
+	// replace all dots to colons
+	return strings.ReplaceAll(monitorId, ".", "::")
 }
 
 // convertSingleMonitor converts a single YAML monitor to proto for a specific monitored ID


### PR DESCRIPTION
# Why
More client friendly monitored ids support. No need have colon convention in path.
Both formats are supported `bq-synq-demo::nyc_taxi::financial_statement` == `bq-synq-demo.nyc_taxi.financial_statement`

This PR is also adding this dot convention to exported monitoredIds logic + test export snapshots so we will be able track changes and detect not required changes.